### PR TITLE
Fix breadcrumb link on blog/manage

### DIFF
--- a/views/blog/manage.pug
+++ b/views/blog/manage.pug
@@ -7,7 +7,7 @@ block content
       | &nbsp;&nbsp;/&nbsp;
       a(href='/blog') Blog
       | &nbsp;&nbsp;/&nbsp;
-      a(href='/blog/manage') Manage
+      a(href='/admin/blog/manage') Manage
 
   .page-header
     h3 Manage Blog Posts


### PR DESCRIPTION
'Manage' breadcrumb in blog/manage directs to /blog/manage instead of /admin/blog/manage