### PR TITLE
reroute event manage/new post commands to admin/events/manage

### DIFF
--- a/controllers/events/postEventsManage.js
+++ b/controllers/events/postEventsManage.js
@@ -35,5 +35,5 @@ function postEventsManage (req, res) {
     })
   })
   req.flash('success', {msg: 'Success! You updated events.'})
-  return res.redirect('/events/manage/')
+  return res.redirect('/admin/events/manage/')
 }

--- a/controllers/events/postEventsNew.js
+++ b/controllers/events/postEventsNew.js
@@ -30,5 +30,5 @@ function postEventsNew (req, res) {
     if (err) console.error(err)
   })
   req.flash('success', {msg: 'Success! You have created an event.'})
-  res.redirect('/events/new')
+  res.redirect('/admin/events/manage')
 }


### PR DESCRIPTION
- Change redirect routes for POST events-manage/new so that they no longer go to events/(id)manage or events/(id)new views. Redirects now to admin/events/manage. 